### PR TITLE
Add an property to exclude branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ following property:
 
 * `branches`: *Optional.* An array of branch name filters. If not specified,
   all branches are tracked.
+* `excluded_branches`: *Optional* A Regex for branches to be excluded. If not specified,
+  no branches are excluded.
 
 The `branch` configuration from the original resource is ignored for `check`.
 
@@ -42,6 +44,16 @@ resources:
   source:
     uri: https://github.com/concourse/atc
     branches: [wip-*]
+```
+Resource configuration for a repo with version and branches beginning with feature/ filtered out:
+
+``` yaml
+resources:
+- name: my-repo-with-feature-branches
+  type: git-branch-heads
+  source:
+    uri: https://github.com/concourse/atc
+    excluded_branches: version|feature/.*
 ```
 
 ## Behavior

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ following property:
 
 * `branches`: *Optional.* An array of branch name filters. If not specified,
   all branches are tracked.
-* `excluded_branches`: *Optional* A Regex for branches to be excluded. If not specified,
+* `exclude`: *Optional* A Regex for branches to be excluded. If not specified,
   no branches are excluded.
 
 The `branch` configuration from the original resource is ignored for `check`.
@@ -53,7 +53,7 @@ resources:
   type: git-branch-heads
   source:
     uri: https://github.com/concourse/atc
-    excluded_branches: version|feature/.*
+    exclude: version|feature/.*
 ```
 
 ## Behavior

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ resources:
     uri: https://github.com/concourse/atc
     branches: [wip-*]
 ```
-Resource configuration for a repo with version and branches beginning with feature/ filtered out:
+Resource configuration for a repo with `version` and branches beginning with `feature/` filtered out:
 
 ``` yaml
 resources:

--- a/assets/check
+++ b/assets/check
@@ -18,6 +18,7 @@ configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
 exclude_branches=$(jq -r '.source.exclude // ""' < $payload)
+e_point=!
 branch_filter=$(jq -r '.source.branches // [] | join(" ")' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 
@@ -25,7 +26,7 @@ previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
 configure_git_global "${git_config_payload}"
 
-current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk '$1 !~ "^($excluded_branches)$"' | sort)
+current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk "\$1 $e_point~ $exclude_branches" | sort)
 
 
 current_heads_map=$(

--- a/assets/check
+++ b/assets/check
@@ -17,7 +17,7 @@ configure_git_ssl_verification $payload
 configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
-exclude_branches=$(jq -r '.source.excluded_branches // ""' < $payload)
+exclude_branches=$(jq -r '.source.exclude // ""' < $payload)
 branch_filter=$(jq -r '.source.branches // [] | join(" ")' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 

--- a/assets/check
+++ b/assets/check
@@ -26,7 +26,7 @@ previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
 configure_git_global "${git_config_payload}"
 
-current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk "\$1 $e_point~ $exclude_branches" | sort)
+current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk "\$1 $e_point~ \"^($exclude_branches)$\"" | sort)
 
 
 current_heads_map=$(

--- a/assets/check
+++ b/assets/check
@@ -17,6 +17,7 @@ configure_git_ssl_verification $payload
 configure_credentials $payload
 
 uri=$(jq -r '.source.uri // ""' < $payload)
+exclude_branches=$(jq -r '.source.excluded_branches // ""' < $payload)
 branch_filter=$(jq -r '.source.branches // [] | join(" ")' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
 
@@ -24,7 +25,8 @@ previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
 configure_git_global "${git_config_payload}"
 
-current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | sort)
+current_heads=$(git ls-remote -h "$uri" $branch_filter | sed 's/refs\/heads\///' | awk '{print $2, $1}' | awk '$1 !~ "^($excluded_branches)$"' | sort)
+
 
 current_heads_map=$(
   jq -n '


### PR DESCRIPTION
can now use `exclude:` property to filter out branches. Ex: `exclude: version|feature/.*`