### PR TITLE
populate the current branch name into a file

### DIFF
--- a/assets/in
+++ b/assets/in
@@ -20,3 +20,7 @@ jq \
   ${GIT_RESOURCE_IN:-/opt/git-resource/in} "$@" |
   jq --slurpfile payload $payload \
     '. + {version: ($payload | .[0].version)}'
+
+cd "$@"
+mkdir .git/git-branch-heads-resource
+jq < $payload -r .version.changed > .git/git-branch-heads-resource/branch


### PR DESCRIPTION
## Why?
When we tried to get the current branch name in our task by running "git branch", the output looked like this
$git branch
\* (detached)
current_branch_name

If I understand correctly, the "detached" should be caused by https://github.com/concourse/git-resource/blob/master/assets/in#L67. It's able to get the current branch name, but not in a very clean way.

Moreover, the current branch name could be quite useful as the resource traces multiple branches. It would be helpful to populate the current branch name into a file.

## How
Create a dedicated directory "git-branch-heads-resource" under ".git".
Populate the current branch name into the file ".git/git-branch-heads-resource/branch".

## Test
Built the docker image xjzhang/git-branch-heads-resource-test  here https://hub.docker.com/r/xjzhang/git-branch-heads-resource-test/ and tested.