### PR TITLE
Add a changed_only source parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ following property:
   all branches are tracked.
 * `exclude`: *Optional* A Regex for branches to be excluded. If not specified,
   no branches are excluded.
+* `changed_only`: *Optional* If true, the resource will only show the changed branch heads and not all of them. Useful for repos with many active branches. Defaults to false
 
 The `branch` configuration from the original resource is ignored for `check`.
 

--- a/assets/check
+++ b/assets/check
@@ -50,12 +50,12 @@ changed=$(echo "$current_heads" |
   done)
 
 if [[ "$changed_only" == "true" ]]; then
-  echo "$changed" |
+  echo -n "$changed" |
   jq -R . |
   jq -s 'map({changed: ., (.): $branches[.]})' \
     --argjson branches "$current_heads_map" --arg changed "$changed" >&3
 else
-  echo "$changed" |
+  echo -n "$changed" |
   jq -R . |
   jq -s 'map({changed: .} + $branches)' \
     --argjson branches "$current_heads_map" >&3

--- a/assets/check
+++ b/assets/check
@@ -20,6 +20,7 @@ uri=$(jq -r '.source.uri // ""' < $payload)
 exclude_branches=$(jq -r '.source.exclude // ""' < $payload)
 branch_filter=$(jq -r '.source.branches // [] | join(" ")' < $payload)
 git_config_payload=$(jq -r '.source.git_config // []' < $payload)
+changed_only="$(jq -r '.source.changed_only // false' < $payload)"
 
 previous_branches="$(jq -r '.version.branches // ""' < $payload)"
 
@@ -36,7 +37,7 @@ current_heads_map=$(
   ' --arg heads "$current_heads"
 )
 
-echo "$current_heads" |
+changed=$(echo "$current_heads" |
   while read branch ref; do
     if [ -z "$branch" ]; then
       continue
@@ -46,7 +47,16 @@ echo "$current_heads" |
     if [ "$ref" != "$prev_ref" ]; then
       echo "$branch"
     fi
-  done |
+  done)
+
+if [[ "$changed_only" == "true" ]]; then
+  echo "$changed" |
+  jq -R . |
+  jq -s 'map({changed: ., (.): $branches[.]})' \
+    --argjson branches "$current_heads_map" --arg changed "$changed" >&3
+else
+  echo "$changed" |
   jq -R . |
   jq -s 'map({changed: .} + $branches)' \
     --argjson branches "$current_heads_map" >&3
+fi

--- a/test/check.sh
+++ b/test/check.sh
@@ -183,6 +183,27 @@ it_can_check_with_removed_branch() {
   ' --arg refa1 "$refa1" --arg refmaster1 "$refmaster1"
 }
 
+it_can_check_with_changed_only() {
+  local repo=$(init_repo)
+
+  local refmaster1=$(git -C $repo rev-parse master)
+  local refa1=$(make_commit_to_branch $repo branch-a)
+  local refb1=$(make_commit_to_branch $repo branch-b)
+
+  check_uri_changed_only $repo | jq -e '
+    . == [{
+      changed: "branch-a",
+      "branch-a": $refa1,
+    },{
+      changed: "branch-b",
+      "branch-b": $refb1,
+    },{
+      changed: "master",
+      "master": $refmaster1
+    }]
+  ' --arg refa1 "$refa1" --arg refb1 "$refb1" --arg refmaster1 "$refmaster1"
+}
+
 run it_can_check_from_no_version
 run it_can_check_from_no_version_with_filter
 run it_can_check_from_no_version_with_filters
@@ -190,3 +211,4 @@ run it_can_check_with_updated_branch
 run it_can_check_with_updated_branches
 run it_can_check_with_added_branch
 run it_can_check_with_removed_branch
+run it_can_check_with_changed_only

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -105,6 +105,15 @@ check_uri_from() {
   }' --arg uri "$uri" --argjson branches "$branches" | ${resource_dir}/check | tee /dev/stderr
 }
 
+check_uri_changed_only() {
+  jq -n '{
+    source: {
+      uri: $uri,
+			changed_only: true
+    }
+  }' --arg uri "$1" | ${resource_dir}/check | tee /dev/stderr
+}
+
 get_changed_branch() {
   uri=$1
   dest=$2


### PR DESCRIPTION
I know that this resource is marked deprecated but we still find it immensely useful. It seems to be the only reasonable way to run something (unit tests, container builder, etc) on every commit on a branch.

We also struggle a bit with branch cleanup though. So the output of the checks and thus the versions of the resource often look very verbose. This PR adds a `changed_only` parameter to the resource config that, if true, will only display the branch that has changed. This parameter defaults to false, meaning the original behavior is the same.

This basically changes the display of the resource from this:
![image](https://user-images.githubusercontent.com/797259/95238368-4489e300-07be-11eb-89f0-ba9bfebc4341.png)
to this:
![image](https://user-images.githubusercontent.com/797259/95238475-6d11dd00-07be-11eb-86a8-1483fb85dfc5.png)


I understand if this doesn't get merged since this is a deprecated repo, but we've found this change useful so I thought I'd share it with others!